### PR TITLE
Add 64bit int support

### DIFF
--- a/ext/mini_racer_extension/mini_racer_extension.cc
+++ b/ext/mini_racer_extension/mini_racer_extension.cc
@@ -221,17 +221,18 @@ static Handle<Value> convert_ruby_to_v8(Isolate* isolate, VALUE value) {
     VALUE pair;
     int i;
     long length;
+    long fixnum;
     VALUE klass;
 
     switch (TYPE(value)) {
     case T_FIXNUM:
-        length = NUM2INT(rb_funcall(value, rb_intern("size"), 0));
-        if (length > 4)
+        fixnum = NUM2LONG(value);
+        if (fixnum > INT_MAX)
         {
-            return scope.Escape(Number::New(isolate, NUM2DBL(value)));
+            return scope.Escape(Number::New(isolate, (double)fixnum));
         }
         
-        return scope.Escape(Integer::New(isolate, NUM2INT(value)));
+        return scope.Escape(Integer::New(isolate, (int)fixnum));
     case T_FLOAT:
 	return scope.Escape(Number::New(isolate, NUM2DBL(value)));
     case T_STRING:

--- a/ext/mini_racer_extension/mini_racer_extension.cc
+++ b/ext/mini_racer_extension/mini_racer_extension.cc
@@ -215,7 +215,13 @@ static Handle<Value> convert_ruby_to_v8(Isolate* isolate, VALUE value) {
 
     switch (TYPE(value)) {
     case T_FIXNUM:
-	return scope.Escape(Integer::New(isolate, NUM2INT(value)));
+        length = NUM2INT(rb_funcall(value, rb_intern("size"), 0));
+        if (length > 4)
+        {
+            return scope.Escape(Number::New(isolate, NUM2DBL(value)));
+        }
+        
+        return scope.Escape(Integer::New(isolate, NUM2INT(value)));
     case T_FLOAT:
 	return scope.Escape(Number::New(isolate, NUM2DBL(value)));
     case T_STRING:

--- a/test/mini_racer_test.rb
+++ b/test/mini_racer_test.rb
@@ -179,6 +179,15 @@ raise FooError, "I like foos"
     # check that no precision is lost in the marshalling (js only stores milliseconds)
     assert_equal((test_time.tv_usec/1000.0).floor, (result.tv_usec/1000.0).floor)
   end
+  
+  def test_return_large_number
+    context = MiniRacer::Context.new
+    test_num = 1_000_000_000_000_000
+    context.attach("test", proc{test_num})
+    
+    assert_equal(true, context.eval("test() === 1000000000000000"))
+    assert_equal(test_num, context.eval("test()"))
+  end
 
   def test_return_unknown
     context = MiniRacer::Context.new

--- a/test/mini_racer_test.rb
+++ b/test/mini_racer_test.rb
@@ -201,6 +201,15 @@ raise FooError, "I like foos"
     assert_equal(true, context.eval("test() === 1000000000000000"))
     assert_equal(test_num, context.eval("test()"))
   end
+  
+  def test_return_int_max
+    context = MiniRacer::Context.new
+    test_num = 2 ** (31) - 1 #last int32 number
+    context.attach("test", proc{test_num})
+    
+    assert_equal(true, context.eval("test() === 2147483647"))
+    assert_equal(test_num, context.eval("test()"))
+  end
 
   def test_return_unknown
     context = MiniRacer::Context.new


### PR DESCRIPTION
converts to a double to get it across the line and back. (ala therubyracer)
trying to do this without the patch will throw a can't convert int64 to int32 exception