### PR TITLE
Adjust header inclusions for changes in V8 5.1.11

### DIFF
--- a/ext/mini_racer_extension/mini_racer_extension.cc
+++ b/ext/mini_racer_extension/mini_racer_extension.cc
@@ -1,8 +1,8 @@
 #include <stdio.h>
 #include <ruby.h>
 #include <ruby/thread.h>
-#include <include/v8.h>
-#include <include/libplatform/libplatform.h>
+#include <v8.h>
+#include <libplatform/libplatform.h>
 #include <ruby/encoding.h>
 #include <pthread.h>
 #include <unistd.h>

--- a/mini_racer.gemspec
+++ b/mini_racer.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "rake-compiler"
 
-  spec.add_dependency 'libv8', '~> 5.0', '< 5.1.11'
+  spec.add_dependency 'libv8', '~> 5.1'
   spec.require_paths = ["lib", "ext"]
 
   spec.extensions = ["ext/mini_racer_extension/extconf.rb"]


### PR DESCRIPTION
Since [1] V8 finally assumes that v8/include is in the include path.

[1] https://chromium.googlesource.com/v8/v8/+/e8c914f18fd88cd58aaaf5d8cee53b9e57477b52

**merge after releasing a version with #20 merged**