### PR TITLE
Set an upper limit on the version of libv8

### DIFF
--- a/mini_racer.gemspec
+++ b/mini_racer.gemspec
@@ -25,11 +25,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "rake-compiler"
 
-  spec.add_dependency 'libv8', '~> 5.0'
+  spec.add_dependency 'libv8', '~> 5.0', '< 5.1.11'
   spec.require_paths = ["lib", "ext"]
 
   spec.extensions = ["ext/mini_racer_extension/extconf.rb"]
 
   spec.required_ruby_version = '>= 2.0'
-
 end


### PR DESCRIPTION
OK, so here's the issue.

In the current state of the gems, if we don't synchronize the releases of a new version of mini_racer with https://github.com/discourse/mini_racer/pull/19 and the new version of libv8, new mini_racer installs will fail.

I suggest:

1. You release a new version of mini_racer that sets this upper limit on the libv8 version
2. I release the new libv8 version
3. You release a new version of mini_racer with https://github.com/discourse/mini_racer/pull/19 merged.