### PR TITLE
Making it possible to share isolates between contexts

### DIFF
--- a/lib/mini_racer.rb
+++ b/lib/mini_racer.rb
@@ -150,7 +150,7 @@ module MiniRacer
     end
   end
 
-  # `size` and `warmup` public methods are defined in the C class
+  # `size` and `warmup!` public methods are defined in the C class
   class Snapshot
     def initialize(str = '')
       # defined in the C class


### PR DESCRIPTION
Allocating and then freeing V8 `Isolate`s turns out to be pretty expensive at times.

This patch makes sharing isolates possible by introducing a new `MiniRacer::Isolate` object,
which can be initialized with a `MiniRacer::Snapshot` object.
That isolate object can then be used to create a new context: `MiniRacer::Context.new(isolate: isolate)`
Of course that must be used with special care (probably not used at all, actually)
in multi-threaded code, but works with no particular caveats otherwise.

Example snippet:
```
snapshot = MiniRacer::Snapshot.new(my_snippet)
isolate = MiniRacer::Isolate.new(snapshot)

# now that isolate can be shared across as many contexts as desired
context1 = MiniRacer::Context.new(isolate: isolate)
context2 = MiniRacer::Context.new(isolate: isolate)
```

This patch introduces no breaking changes; in particular, contexts still get their
own isolate by default.

Particular care has been taken for memory management, with multiple tests on that.