### PR TITLE
Bump xcode version to 8 in the Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
   include:
     - rvm: 2.2
       os: osx
-      osx_image: xcode7.3
+      osx_image: xcode8
 dist: trusty
 sudo: true
 before_install:


### PR DESCRIPTION
This is done in preparation for macOS Sierra rollout[1]

[1] https://blog.travis-ci.com/2016-09-15-new-default-osx-image-coming/