### PR TITLE
Add memory softlimit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,17 @@ context.eval 'while(true){}'
 # => exception is raised
 ```
 
+### Memory softlimit support
+
+Contexts can specify a memory softlimit for scripts
+
+```ruby
+# terminates script if heap usage exceeds 200mb after V8 garbage collection has run
+context = MiniRacer::Context.new(max_memory: 200000000)
+context.eval 'var a = new Array(10000); while(true) {a = a.concat(new Array(10000)); print("loop " + a.length);}'
+# => V8OutOfMemoryError is raised
+```
+
 ### Rich debugging with "filename" support
 
 ```ruby

--- a/lib/mini_racer.rb
+++ b/lib/mini_racer.rb
@@ -14,6 +14,7 @@ module MiniRacer
   class EvalError < Error; end
   class ParseError < EvalError; end
   class ScriptTerminatedError < EvalError; end
+  class V8OutOfMemoryError < EvalError; end
 
   class FailedV8Conversion
     attr_reader :info
@@ -144,8 +145,10 @@ module MiniRacer
 
       @functions = {}
       @timeout = nil
+      @max_memory = nil
       @current_exception = nil
       @timeout = options[:timeout]
+      @max_memory = options[:max_memory]
       @isolate = options[:isolate] || Isolate.new(options[:snapshot])
       @disposed = false
 

--- a/test/mini_racer_test.rb
+++ b/test/mini_racer_test.rb
@@ -283,6 +283,13 @@ raise FooError, "I like foos"
     assert_equal("Undefined Conversion", context.eval("test()"))
   end
 
+  def test_fatal_alloc
+    context = MiniRacer::Context.new(max_memory: 200000000)
+    context.attach("print", proc{|a| a})
+
+    assert_raises(MiniRacer::V8OutOfMemoryError) { context.eval('var a = new Array(10000); while(true) {a = a.concat(new Array(10000)); print("loop " + a.length);}') }
+  end
+
   module Echo
     def self.say(thing)
       thing


### PR DESCRIPTION
Closes discourse/mini_racer#18
I've been working on adding this feature per conversations with @seanmakesgames.

I've added a callback to the GC Epilogue that checks percentage of heap used against a user-defined value (provided at Context creation).  This will help prevent OOMs in well-behaved code, but can not detect or prevent large allocations causing an OOM to happen.

I've added two new isolate data buckets to store the softlimit threshold as well as a flag to show the softlimit was reached.  I'm not convinced this is the best way as further features and flags could continue to pile on and create excessive GetData / SetData code blocks.  My current thought for a better solution would be to pass around a struct via isolate Get/SetData that contains configuration and flag information.

My other point of uncertainty is whether or not stopping attached code is needed in the gc callback.  Unless I am mistaken it should not be necessary as attached code will not be allocating in the V8 heap, so any V8 garbage collection events should be from `eval`'ed code only.  

I also fixed a typo, and had to import two modules in the test class to get it to run.  My apologies for bundling them in this PR, I would be happy to remove those changes if desired.