### PR TITLE
fix minitest deprecation notices

### DIFF
--- a/test/mini_racer_test.rb
+++ b/test/mini_racer_test.rb
@@ -29,8 +29,8 @@ class MiniRacerTest < Minitest::Test
     assert_equal 2.1, context.eval('2.1')
     assert_equal true, context.eval('true')
     assert_equal false, context.eval('false')
-    assert_equal nil, context.eval('null')
-    assert_equal nil, context.eval('undefined')
+    assert_nil context.eval('null')
+    assert_nil context.eval('undefined')
   end
 
   def test_array


### PR DESCRIPTION
DEPRECATED: Use assert_nil if expecting nil from /Users/user/mini_racer/test/mini_racer_test.rb:32. This will fail in Minitest 6.