### PR TITLE
Add gvl reacquisition crash test case and resolution

### DIFF
--- a/test/mini_racer_test.rb
+++ b/test/mini_racer_test.rb
@@ -686,4 +686,12 @@ raise FooError, "I like foos"
       context.dispose
     end
   end
+
+  def test_attached_recursion
+    context = MiniRacer::Context.new(timeout: 20)
+    context.attach("a", proc{|a| a})
+    context.attach("b", proc{|a| a})
+
+    context.eval('const obj = {get r(){ b() }}; a(obj);')
+  end
 end


### PR DESCRIPTION
Closes #69

When running attached code, gvl is acquired if it is not already obtained, but the isolate is not informed of this state change.  I changed the isolate GetData/SetData to use an enum for clarity, and wrapped the gvl-acquiring callback in what should be the proper state manipulation logic to prevent the crash as described in the issue linked above.  Test case has been added and is passing with the code change.