### PR TITLE
Add ability to dump snapshot to string

### DIFF
--- a/ext/mini_racer_extension/mini_racer_extension.cc
+++ b/ext/mini_racer_extension/mini_racer_extension.cc
@@ -562,6 +562,13 @@ static VALUE rb_snapshot_load(VALUE self, VALUE str) {
     return Qnil;
 }
 
+static VALUE rb_snapshot_dump(VALUE self, VALUE str) {
+    SnapshotInfo* snapshot_info;
+    Data_Get_Struct(self, SnapshotInfo, snapshot_info);
+
+    return rb_str_new(snapshot_info->data, snapshot_info->raw_size);
+}
+
 static VALUE rb_snapshot_warmup_unsafe(VALUE self, VALUE str) {
     SnapshotInfo* snapshot_info;
     Data_Get_Struct(self, SnapshotInfo, snapshot_info);
@@ -1382,6 +1389,7 @@ extern "C" {
 	rb_define_alloc_func(rb_cExternalFunction, allocate_external_function);
 
 	rb_define_method(rb_cSnapshot, "size", (VALUE(*)(...))&rb_snapshot_size, 0);
+	rb_define_method(rb_cSnapshot, "dump", (VALUE(*)(...))&rb_snapshot_dump, 0);
 	rb_define_method(rb_cSnapshot, "warmup_unsafe!", (VALUE(*)(...))&rb_snapshot_warmup_unsafe, 1);
 	rb_define_private_method(rb_cSnapshot, "load", (VALUE(*)(...))&rb_snapshot_load, 1);
 

--- a/test/mini_racer_test.rb
+++ b/test/mini_racer_test.rb
@@ -363,6 +363,15 @@ raise FooError, "I like foos"
     assert(snapshot.size > 0)
   end
 
+  def test_snapshot_dump
+    snapshot = MiniRacer::Snapshot.new('var foo = "bar";')
+    dump = snapshot.dump
+
+    assert_equal(String, dump.class)
+    assert_equal(Encoding::ASCII_8BIT, dump.encoding)
+    assert_equal(snapshot.size, dump.length)
+  end
+
   def test_invalid_snapshots_throw_an_exception
     assert_raises(MiniRacer::SnapshotError) do
       MiniRacer::Snapshot.new('var foo = bar;')


### PR DESCRIPTION
In the future, I would like to be able to dump snapshot to a file and then load the binary snapshot file in a different process.  In order to do that, first we need to be able to dump the snapshot so it can be saved somewhere. `Snapshot#dump` is the first step in making that happen.  `Snapshot#dump` returns an ASCII-8BIT string which can then be saved off.

My next step after this is merged will be to work on loading this snapshot binary. Let me know if you see any issues, still learning the Ruby C api :)