### PR TITLE
Use libc++ on Mojave (fixes #96)

### DIFF
--- a/ext/mini_racer_extension/extconf.rb
+++ b/ext/mini_racer_extension/extconf.rb
@@ -11,7 +11,7 @@ $CPPFLAGS += " -std=c++0x"
 $CPPFLAGS += " -fpermissive"
 $CPPFLAGS += " -Wno-reserved-user-defined-literal" if RUBY_PLATFORM =~ /darwin/
 
-$LDFLAGS.insert 0, " -stdlib=libstdc++ " if RUBY_PLATFORM =~ /darwin/
+$LDFLAGS.insert 0, $1.to_i < 18 ? " -stdlib=libstdc++ " : " -stdlib=libc++ " if RUBY_PLATFORM =~ /darwin(\d+)/
 
 if ENV['CXX']
   puts "SETTING CXX"


### PR DESCRIPTION
Using libstdc++ is deprecated on macOS 10.14, therefore selectively
build against libc++ based on the reported platform version. Since this
platform check is persisted upon ruby being built, building will fail if
a given ruby is built before upgrading to Mojave and this gem is
subsequently attempted to be installed.