### PR TITLE
Remove conditional logic and use just libc++ on darwin irregardless of version

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+- Unreleased
+
+  - Drop macOS feature detection and always link against libc++ macOS
+
 - 26-09-2018
 
 - 0.2.2

--- a/ext/mini_racer_extension/extconf.rb
+++ b/ext/mini_racer_extension/extconf.rb
@@ -14,17 +14,7 @@ $CPPFLAGS += " -fpermissive"
 
 $CPPFLAGS += " -Wno-reserved-user-defined-literal" if IS_DARWIN
 
-MAC_OS_VERSION = begin
-  if IS_DARWIN
-    # note, RUBY_PLATFORM is hardcoded on compile, it can not be trusted
-    # sw_vers can be trusted so use it
-    `sw_vers -productVersion`.to_f rescue 0.0
-  else
-    0.0
-  end
-end
-
-$LDFLAGS.insert 0, MAC_OS_VERSION < 10.14 ? " -stdlib=libstdc++ " : " -stdlib=libc++ " if IS_DARWIN
+$LDFLAGS.insert(0, " -stdlib=libc++ ") if IS_DARWIN
 
 if ENV['CXX']
   puts "SETTING CXX"


### PR DESCRIPTION
This fixes https://github.com/discourse/mini_racer/issues/104
Also fixes https://github.com/discourse/mini_racer/issues/107