### PR TITLE
Remove use of non-maybe version of Message functions

### DIFF
--- a/ext/mini_racer_extension/mini_racer_extension.cc
+++ b/ext/mini_racer_extension/mini_racer_extension.cc
@@ -263,11 +263,21 @@ static void prepare_result(MaybeLocal<Value> v8res,
                 evalRes.message = new Persistent<Value>();
                 Local<Message> message = trycatch.Message();
                 char buf[1000];
-                int len;
+                int len, line, column;
+
+                if (!message->GetLineNumber(context).To(&line)) {
+                  line = 0;
+                }
+
+                if (!message->GetStartColumn(context).To(&column)) {
+                  column = 0;
+                }
+
                 len = snprintf(buf, sizeof(buf), "%s at %s:%i:%i", *String::Utf8Value(isolate, message->Get()),
                                *String::Utf8Value(isolate, message->GetScriptResourceName()->ToString()),
-                               message->GetLineNumber(context).ToChecked(),
-                               message->GetStartColumn(context).ToChecked());
+                               line,
+                               column);
+
                 if ((size_t) len >= sizeof(buf)) {
                     len = sizeof(buf) - 1;
                     buf[len] = '\0';

--- a/ext/mini_racer_extension/mini_racer_extension.cc
+++ b/ext/mini_racer_extension/mini_racer_extension.cc
@@ -266,8 +266,8 @@ static void prepare_result(MaybeLocal<Value> v8res,
                 int len;
                 len = snprintf(buf, sizeof(buf), "%s at %s:%i:%i", *String::Utf8Value(isolate, message->Get()),
                                *String::Utf8Value(isolate, message->GetScriptResourceName()->ToString()),
-                               message->GetLineNumber(),
-                               message->GetStartColumn());
+                               message->GetLineNumber(context).ToChecked(),
+                               message->GetStartColumn(context).ToChecked());
                 if ((size_t) len >= sizeof(buf)) {
                     len = sizeof(buf) - 1;
                     buf[len] = '\0';


### PR DESCRIPTION
I think we need to check if these methods return Nothing. @SamSaffron do you have any preference what the printed output should be in case the column or the line are undefined?