### PR TITLE
Lock libv8 to < 7.0

### DIFF
--- a/mini_racer.gemspec
+++ b/mini_racer.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "rake-compiler"
 
-  spec.add_dependency 'libv8', '>= 6.3'
+  spec.add_dependency 'libv8', '>= 6.3', '< 7.0'
   spec.require_paths = ["lib", "ext"]
 
   spec.extensions = ["ext/mini_racer_extension/extconf.rb"]


### PR DESCRIPTION
Currently, there seem to be compilation issues when attempting to compile with
lib8 v7. This patch ensures we only attempt to build the gem against a
compatible v6 version of libv8.