### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/mini_racer.gemspec
+++ b/mini_racer.gemspec
@@ -14,6 +14,12 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/discourse/mini_racer"
   spec.license       = "MIT"
 
+  spec.metadata      = {
+    "bug_tracker_uri"   => "https://github.com/discourse/mini_racer/issues",
+    "changelog_uri"     => "https://github.com/discourse/mini_racer/blob/v#{spec.version}/CHANGELOG",
+    "documentation_uri" => "https://www.rubydoc.info/gems/mini_racer/#{spec.version}",
+    "source_code_uri"   => "https://github.com/discourse/mini_racer/tree/v#{spec.version}",
+  }
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(benchmark|test|spec|features|examples)/}) }
   spec.bindir        = "exe"


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, and `source_code_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/mini_racer), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.